### PR TITLE
Add Axios interceptor to refresh token when it expires

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "axios": "^1.7.2",
     "dayjs": "^1.11.11",
+    "jwt-decode": "^4.0.0",
     "postcss": "^8.4.39",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       dayjs:
         specifier: ^1.11.11
         version: 1.11.11
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
       postcss:
         specifier: ^8.4.39
         version: 8.4.39
@@ -1796,6 +1799,10 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4421,6 +4428,8 @@ snapshots:
       array.prototype.flat: 1.3.2
       object.assign: 4.1.5
       object.values: 1.2.0
+
+  jwt-decode@4.0.0: {}
 
   keyv@4.5.4:
     dependencies:

--- a/src/@types/Credentials.ts
+++ b/src/@types/Credentials.ts
@@ -18,6 +18,11 @@ export type SuccessLoginResponse = {
   birthdate: string;
   token: string;
 };
+
+export type SuccessRefreshResponse = {
+  token: string;
+};
+
 export type SuccessProfilResponse = {
   id: number;
   firstname: string;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,59 @@
-import axios from 'axios';
-import { LoginCredentials, SignupCredentials } from './@types/Credentials';
+import { EnhancedStore } from '@reduxjs/toolkit';
+import axios, { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { jwtDecode } from 'jwt-decode';
+import { LoginCredentials, SignupCredentials, SuccessRefreshResponse } from './@types/Credentials';
 import { MoviesFilter, ParamsType } from './@types/MovieState';
+import { logout, updateToken } from './features/settingsSlice';
 
 const instanceAxios = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
 });
+
+export function axiosInterceptor(store: EnhancedStore) {
+  let lastRefresh = 0;
+  const isRefreshRequest = (config: InternalAxiosRequestConfig) => {
+    return config.url?.slice(-14) === '/refresh-token';
+  };
+  // axios interceptor before any request to refresh token before it expires
+  instanceAxios.interceptors.request.use(
+    async (config: InternalAxiosRequestConfig) => {
+      const token = store.getState().settings.user.token;
+      if (token) {
+        const currentTime = Math.floor(Date.now() / 1000);
+        const decodedToken = jwtDecode(token) as { exp: number };
+        if (
+          decodedToken.exp &&
+          // refresh token 1 minute before expiration
+          decodedToken.exp - currentTime < 30 &&
+          // don't refresh again if last refresh was less than 2 seconds ago
+          currentTime - lastRefresh > 2 &&
+          // don't refresh token if the request is already a refresh
+          !isRefreshRequest(config)
+        ) {
+          lastRefresh = currentTime;
+          try {
+            const response = await refreshToken();
+            const { token: newToken } = response.data.data as SuccessRefreshResponse;
+            store.dispatch(updateToken(newToken)); // update token in settings state
+            config.headers.Authorization = `Bearer ${newToken}`;
+          } catch (error) {
+            console.log(error);
+            store.dispatch(logout());
+            return Promise.reject(new Error('Token refresh failed, user is logged out'));
+          }
+        } else if (currentTime - lastRefresh <= 2 && !isRefreshRequest(config)) {
+          // already refreshed just a sec ago, wait that state gets the new token from previous refresh attempt
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          const newToken = store.getState().settings.user.token;
+          config.headers.Authorization = `Bearer ${newToken}`;
+        }
+      }
+      return config;
+    },
+    (error) => Promise.reject(error)
+  );
+}
 
 //#region ==========     User      ==========
 
@@ -14,6 +63,11 @@ export async function login(credentials: LoginCredentials) {
 }
 export async function register(credentials: SignupCredentials) {
   const response = await instanceAxios.post('/auth/register', credentials);
+  return response;
+}
+export async function refreshToken(): Promise<AxiosResponse> {
+  // not executed in a thunk so no rejected action, we need to use try/catch
+  const response = await instanceAxios.post('/auth/refresh-token');
   return response;
 }
 export async function getProfil() {

--- a/src/components/PlaylistPage/PlaylistPage.tsx
+++ b/src/components/PlaylistPage/PlaylistPage.tsx
@@ -111,16 +111,13 @@ const PlaylistPage: React.FC = () => {
   const openSidebar = (playlist: PlaylistIdentityType) => {
     dispatch(actionFetchPlaylist(playlist.id));
     document.querySelector('.sidebarPlaylist')?.classList.add('visible');
-    console.log('Barre latérale ouverte pour la playlist:', playlist.name);
   };
 
   const closeSidebar = () => {
-    console.log('Fermeture de la barre latérale...');
     dispatch(actionResetCurrentPlaylist());
     setSortedMovies([]);
     setLoading(false);
     document.querySelector('.sidebarPlaylist')?.classList.remove('visible');
-    console.log('Barre latérale fermée');
   };
 
 

--- a/src/features/settingsSlice.ts
+++ b/src/features/settingsSlice.ts
@@ -38,6 +38,11 @@ const settingsSlice = createSlice({
       api.removeTokenJWTToAxiosInstance();
       removeStoreUser();
     },
+    updateToken: (state, action: PayloadAction<string>) => {
+      state.user.token = action.payload;
+      state.user.logged = true;
+      setStoreUser(state.user);
+    },
     editFirstname: (state, action: PayloadAction<string>) => {
       state.user.firstname = action.payload;
     },
@@ -108,5 +113,13 @@ export const selectUser = (state: RootState) => state.settings.user;
 
 export default settingsSlice.reducer;
 
-export const { logout, resetMessages, editEmail, editPassword, editFirstname, editLastName, editBirthdate } =
-  settingsSlice.actions;
+export const {
+  logout,
+  updateToken,
+  resetMessages,
+  editEmail,
+  editPassword,
+  editFirstname,
+  editLastName,
+  editBirthdate,
+} = settingsSlice.actions;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import { axiosInterceptor } from '../api';
 import moviesReducer from '../features/moviesSlice';
 import playlistReducer from '../features/playlistSlice';
 import settingsReducer from '../features/settingsSlice';
@@ -7,6 +8,8 @@ import settingsReducer from '../features/settingsSlice';
 const store = configureStore({
   reducer: { settings: settingsReducer, movies: moviesReducer, playlist: playlistReducer },
 });
+
+axiosInterceptor(store);
 
 export default store;
 


### PR DESCRIPTION
This PR improves security of the website by handling the JWT token expiration.
A renewed token every 15 minutes is more secure.
User still have to log again every 24h.

### How
[Axios interceptor](https://axios-http.com/docs/interceptors) adds some checks that are run before each request is sent to API.
In those check, I wrote the test of token expiration and the trigger of a request to API for a new JWT token if needed.

It will send a POST request to `/auth/refresh-token` to renew the token.

⚠️ Therefore, back-end must be updated in the same time :
- https://github.com/simonc56/filmovies-back/pull/2